### PR TITLE
Avoid NPE if there is no launchConfig entry in the .eosgi.dist.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.everit.osgi.dev</groupId>
   <artifactId>org.everit.osgi.dev.dist.util</artifactId>
-  <version>6.0.0</version>
+  <version>6.0.1-SNAPSHOT</version>
 
   <packaging>bundle</packaging>
 

--- a/src/main/java/org/everit/osgi/dev/dist/util/configuration/DistributedEnvironmentConfigurationProvider.java
+++ b/src/main/java/org/everit/osgi/dev/dist/util/configuration/DistributedEnvironmentConfigurationProvider.java
@@ -79,6 +79,9 @@ public class DistributedEnvironmentConfigurationProvider {
     }
 
     LaunchConfigType launchConfig = overriddenDistributionPackage.getLaunchConfig();
+    if (launchConfig == null) {
+      return null;
+    }
 
     String mainClass = launchConfig.getMainClass();
     String classpath = launchConfig.getClassPath();
@@ -127,6 +130,9 @@ public class DistributedEnvironmentConfigurationProvider {
     }
 
     LaunchConfigType launchConfig = distributionPackageType.getLaunchConfig();
+    if (launchConfig == null) {
+      return distributionPackageType;
+    }
 
     LaunchConfigOverridesType launchConfigOverrides = launchConfig.getOverrides();
     if (launchConfigOverrides == null) {


### PR DESCRIPTION
Fix for https://github.com/everit-org/eosgi-maven-plugin/issues/37